### PR TITLE
Switch method for checking for USERPROFILE env variable

### DIFF
--- a/mdimechanic/cmd_interactive.py
+++ b/mdimechanic/cmd_interactive.py
@@ -20,7 +20,7 @@ def start( image_name, base_path ):
     if found_file:
         gitconfig_line = " -v " + linux_location + ":/root/.gitconfig"
     else: # Check if this is Windows
-        windows_location = os.path.join( str( os.environ['USERPROFILE'] ), ".gitconfig" )
+        windows_location = os.path.join( str( os.getenv('USERPROFILE') ), ".gitconfig" )
         found_file = os.path.exists( windows_location )
         if found_file:
             gitconfig_line = " -v " + windows_location + ":/root/.gitconfig"
@@ -35,7 +35,7 @@ def start( image_name, base_path ):
     if found_file:
         ssh_line = " -v " + linux_location + ":/root/.ssh"
     else: # Check if this is Windows
-        windows_location = os.path.join( str( os.environ['USERPROFILE'] ), ".ssh" )
+        windows_location = os.path.join( str( os.getenv('USERPROFILE')), ".ssh" )
         found_file = os.path.exists( windows_location )
         if found_file:
             ssh_line = " -v " + windows_location + ":/root/.ssh"


### PR DESCRIPTION
## Description
This PR changes the checking method for the `USERPROFILE` environment variable from `os.environ` to `os.getenv`. Using the current method (`os.environ`) will cause an Exception (I believe a `KeyError`) if on a Linux machine that does not have a `.ssh` folder or a `.gitconfig` file. 

The intended behavior is that the program should continue executing and warn the user that the files were not found. By using `os.getenv`, `None` is returned when that variable is checked, meaning that the file is not found and the user is warned (instead of program halting)

Fixes #14 
